### PR TITLE
fix: Fix typo in --move-decompiler in main.py

### DIFF
--- a/src/python/package_graphql_poller/main.py
+++ b/src/python/package_graphql_poller/main.py
@@ -297,7 +297,7 @@ if __name__ == "__main__":
     )
 
     arg_parser.add_argument(
-        "--move-decompiler", required=True, help="The move-decopmiler binary to be used"
+        "--move-decompiler", required=True, help="The move-decompiler binary to be used"
     )
 
     args = arg_parser.parse_args()


### PR DESCRIPTION
I noticed a typo in the help text for the `--move-decompiler` argument. The word "move-decopmiler" was misspelled.
I've corrected it to "**move-decompiler**" to ensure clarity and consistency.  

**Thanks for SUI!**